### PR TITLE
add step to install and run a containerization desktop tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@ We welcome everyone to contribute to Flowmodor. This document is to help you und
 1. Clone the repository: `git clone https://github.com/flowmodor/flowmodor`
 2. Navigate to the project directory: `cd flowmodor`
 3. Install dependencies: `yarn`
-4. Run Supabase: `npx supabase start`
-5. Create `.env.local` file with following content (replace `API URL` and `anon key` with the output string from step 4.):
+4. Install and run a containerization tool, such as Docker Desktop, OrbStack, podman desktop, or another alternative.
+5. Run Supabase: `npx supabase start`
+6. Create `.env.local` file with following content (replace `API URL` and `anon key` with the output string from step 5.):
 
 ```text
 NEXT_PUBLIC_SUPABASE_URL="API URL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,15 @@ NEXT_PUBLIC_SUPABASE_URL="API URL"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="anon key"
 ```
 
-6. Create `.env` file with the following content (skip this if your are not working with Google OAuth).
+7. Create `.env` file with the following content (skip this if your are not working with Google OAuth).
 
 ```text
 SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET="your google client secret"
 SUPABASE_AUTH_EXTERNAL_GOOGLE_ID="your google client id"
 ```
 
-7. Run the web app: `yarn run dev`
-8. Create a user at [Authentication tab](http://127.0.0.1:54323/project/default/auth/users) and then you can login with it.
+8. Run the web app: `yarn run dev`
+9. Create a user at [Authentication tab](http://127.0.0.1:54323/project/default/auth/users) and then you can login with it.
 
 ## Finding a task
 


### PR DESCRIPTION
Environment: M1 Pro Macbook Pro

Was blocked from running `npx supabase start` and had to ensure I had a containerization desktop tool running (OrbStack in my case but other options like Docker Desktop will suffice)

Added this requirement as step 4. 