### PR TITLE
disable google auth by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ NEXT_PUBLIC_SUPABASE_URL="API URL"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="anon key"
 ```
 
-7. Create `.env` file with the following content (skip this if your are not working with Google OAuth).
+7. If you need Google OAuth feature, create `.env` file with the following content and set `[auth.external.google]` inside `supabase/config.toml` to `enabled = true`.
 
 ```text
 SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET="your google client secret"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -133,7 +133,7 @@ redirect_uri = ""
 url = ""
 
 [auth.external.google]
-enabled = true
+enabled = false
 client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 redirect_uri = "http://localhost:54321/auth/v1/callback"


### PR DESCRIPTION
Issue: Stuck on step 5 of the [install instructions](https://github.com/flowmodor/flowmodor/blob/main/CONTRIBUTING.md) if .env file does not exist (currently, step 7 mentions the .env file for google auth)

![Terminal Error on step 5](https://github.com/flowmodor/flowmodor/assets/14141077/8127f03f-ecd7-46e6-a2e9-09bb56c490e4)

Proposed resolution: set `[auth.external.google]` to `enabled = false` by default.  Then update the installation instructions to include steps to optionally enable google auth if desired.

The alternative is to leave google auth enabled and update the install instructions to request the user to create the .env file prior to step 5.

thoughts on the best approach here?